### PR TITLE
Refactor Option List Printing

### DIFF
--- a/src/main/java/OS.java
+++ b/src/main/java/OS.java
@@ -4,9 +4,12 @@ import systems.lookups.CodeLookup;
 import systems.lookups.ProgramAdvanceLookup;
 import systems.utility.Helpers;
 
+import java.util.ArrayList;
 import java.util.InputMismatchException;
+import java.util.List;
 import java.util.Scanner;
 
+import static systems.utility.Helpers.printOptions;
 import static systems.utility.Helpers.simplePrint;
 
 public class OS {
@@ -37,7 +40,7 @@ public class OS {
         keyboard = new Scanner(System.in);
         boolean programInUse = true;
         while(programInUse) {
-            simplePrint(listCommands());
+            listCommands();
             int input;
             try {
                 input = keyboard.nextInt();
@@ -87,23 +90,17 @@ public class OS {
     }
 
     /**
-     * The main options offered for the BNH.
-     * @return A {@link String} of the top-most menu's options.
+     * Prints the main options offered for the BNH.
      */
-    private static String listCommands() {
-        return """
-        =========
-        Main Menu
-        =========
-        1) Chip Lookup
-        2) P.A. Lookup
-        3) Folder Builder
-        4) Code Lookup
-        5) Edit Config
-        6) Exit
-        
-        Please select an option...
-        """;
+    private static void listCommands() {
+        List<String> commandList = new ArrayList<>();
+        commandList.add("Chip Lookup");
+        commandList.add("P.A. Lookup");
+        commandList.add("Folder Builder");
+        commandList.add("Code Lookup");
+        commandList.add("Edit Config");
+        commandList.add("Exit");
+        printOptions(commandList);
     }
 
     /**

--- a/src/main/java/interfaces/Subsystem.java
+++ b/src/main/java/interfaces/Subsystem.java
@@ -1,6 +1,9 @@
 package interfaces;
 
+import java.util.List;
 import java.util.Scanner;
+
+import systems.utility.Helpers;
 
 /**
  * Represents a system that performs a wide range of ways to perform a specific
@@ -10,6 +13,7 @@ public interface Subsystem {
 
     /**
      * Prints the list of available options to the user.
+     * @see Helpers#printOptions(List)
      */
     void printOptions();
 

--- a/src/main/java/interfaces/subroutines/Subroutine.java
+++ b/src/main/java/interfaces/subroutines/Subroutine.java
@@ -1,9 +1,14 @@
 package interfaces.subroutines;
 
+import java.util.List;
+
+import systems.utility.Helpers;
+
 public interface Subroutine {
 
     /**
      * Prints the list of available options to the user.
+     * @see Helpers#printOptions(List)
      */
     void printOptions();
 }

--- a/src/main/java/systems/lookups/ChipLookup.java
+++ b/src/main/java/systems/lookups/ChipLookup.java
@@ -3,9 +3,11 @@ package systems.lookups;
 import interfaces.Subsystem;
 import org.apache.commons.lang3.StringUtils;
 import pojos.Chip;
+import systems.utility.Helpers;
 import systems.utility.readers.ChipFileReader;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.InputMismatchException;
 import java.util.List;
 import java.util.Scanner;
@@ -37,15 +39,14 @@ public class ChipLookup implements Subsystem {
     @Override
     public void printOptions() {
         simplePrint(System.lineSeparator());
-        simplePrint("""
-        Please select an option
-        1) Search by number
-        2) Search by name
-        3) Search by damage
-        4) Search by code
-        5) Search by memory size
-        6) Return to main menu
-        """);
+        List<String> options = new ArrayList<>();
+        options.add("Search by number");
+        options.add("Search by name");
+        options.add("Search by damage");
+        options.add("Search by code");
+        options.add("Search by memory size");
+        options.add("Return to main menu");
+        Helpers.printOptions(options);
     }
 
     /**

--- a/src/main/java/systems/lookups/CodeLookup.java
+++ b/src/main/java/systems/lookups/CodeLookup.java
@@ -3,10 +3,13 @@ package systems.lookups;
 import interfaces.Subsystem;
 import systems.subroutines.CodeListSubroutine;
 import systems.subroutines.CodeSearchSubroutine;
+import systems.utility.Helpers;
 import systems.utility.readers.CodeFileReader;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.InputMismatchException;
+import java.util.List;
 import java.util.Scanner;
 
 import static systems.utility.Helpers.simplePrint;
@@ -32,12 +35,11 @@ public class CodeLookup implements Subsystem {
     @Override
     public void printOptions() {
         simplePrint(System.lineSeparator());
-        simplePrint("""
-        Please select an option
-        1) List Codes
-        2) Search Codes
-        3) Return to main menu
-        """);
+        List<String> options = new ArrayList<>();
+        options.add("List Codes");
+        options.add("Search Codes");
+        options.add("Return to main menu");
+        Helpers.printOptions(options);
     }
 
     @Override

--- a/src/main/java/systems/lookups/ProgramAdvanceLookup.java
+++ b/src/main/java/systems/lookups/ProgramAdvanceLookup.java
@@ -2,9 +2,11 @@ package systems.lookups;
 
 import interfaces.Subsystem;
 import pojos.ProgramAdvance;
+import systems.utility.Helpers;
 import systems.utility.readers.ProgramAdvanceFileReader;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
 
@@ -31,13 +33,12 @@ public class ProgramAdvanceLookup implements Subsystem {
     @Override
     public void printOptions() {
         simplePrint(System.lineSeparator());
-        simplePrint("""
-        Please select an option
-        1) Search by name
-        2) Search by damage
-        3) Search by chip used
-        4) Return to main menu
-        """);
+        List<String> options = new ArrayList<>();
+        options.add("Search by name");
+        options.add("Search by damage");
+        options.add("Search by chip used");
+        options.add("Return to main menu");
+        Helpers.printOptions(options);
     }
 
     @Override

--- a/src/main/java/systems/subroutines/CodeListSubroutine.java
+++ b/src/main/java/systems/subroutines/CodeListSubroutine.java
@@ -4,9 +4,13 @@ import interfaces.subroutines.ListSubroutine;
 import pojos.navicust.CompressionCode;
 import pojos.navicust.ErrorCode;
 import pojos.navicust.ExCode;
+import systems.utility.Helpers;
 import systems.utility.readers.CodeFileReader;
 
 import static systems.utility.Helpers.simplePrint;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class CodeListSubroutine implements ListSubroutine {
 
@@ -20,14 +24,13 @@ public class CodeListSubroutine implements ListSubroutine {
     @Override
     public void printOptions() {
         simplePrint(System.lineSeparator());
-        simplePrint("""
-        Please select a listing option
-        1) List Extra Codes (ExCodes)
-        2) List Error Codes
-        3) List Compression Codes
-        4) Switch to search mode
-        5) Return to previous menu
-        """);
+        List<String> options = new ArrayList<>();
+        options.add("List Extra Codes (ExCodes)");
+        options.add("List Error Codes");
+        options.add("List Compression Codes");
+        options.add("Switch to search mode");
+        options.add("Return to previous menu");
+        Helpers.printOptions(options);
     }
 
     @Override

--- a/src/main/java/systems/subroutines/CodeSearchSubroutine.java
+++ b/src/main/java/systems/subroutines/CodeSearchSubroutine.java
@@ -4,8 +4,10 @@ import interfaces.subroutines.SearchSubroutine;
 import pojos.navicust.CompressionCode;
 import pojos.navicust.ErrorCode;
 import pojos.navicust.ExCode;
+import systems.utility.Helpers;
 import systems.utility.readers.CodeFileReader;
 
+import java.util.ArrayList;
 import java.util.InputMismatchException;
 import java.util.List;
 import java.util.Scanner;
@@ -23,13 +25,13 @@ public class CodeSearchSubroutine implements SearchSubroutine {
     @Override
     public void printOptions() {
         simplePrint(System.lineSeparator());
-        simplePrint("""
-        1) Search Extra Codes (ExCodes)
-        2) Search Error Codes
-        3) Search Compression Codes
-        4) Switch to list mode
-        5) Return to previous menu
-        """);
+        List<String> options = new ArrayList<>();
+        options.add("Search Extra Codes (ExCodes)");
+        options.add("Search Error Codes");
+        options.add("Search Compression Codes");
+        options.add("Switch to list mode");
+        options.add("Return to previous menu");
+        Helpers.printOptions(options);
     }
 
     @Override

--- a/src/main/java/systems/utility/Helpers.java
+++ b/src/main/java/systems/utility/Helpers.java
@@ -1,5 +1,7 @@
 package systems.utility;
 
+import java.util.List;
+
 public class Helpers {
 
     /**
@@ -22,5 +24,34 @@ public class Helpers {
      */
     public static void simplePrint(String s) {
         System.out.println(s);
+    }
+
+    /**
+     * Constructs a list of selectable options.
+     * <p>
+     * For a list of three options, they are displayed as follows:
+     * </p>
+     * <pre>
+     * 1) Option 1
+     * 2) Option 2
+     * 3) Option 3
+     *
+     * Please select an option...
+     * </pre>
+     *
+     * @param options A {@link String} {@link List} containing the options to
+     * be printed in a formatted string.
+     */
+    public static void printOptions(List<String> options) {
+        int optionNum = 1;
+        StringBuilder optionsListBuilder = new StringBuilder();
+        for (String option : options) {
+            String optionLine = optionNum + ") " + option + System.lineSeparator();
+            optionsListBuilder.append(optionLine);
+            optionNum++;
+        }
+        optionsListBuilder.append(System.lineSeparator());
+        optionsListBuilder.append("Please select an option...");
+        simplePrint(optionsListBuilder.toString());
     }
 }


### PR DESCRIPTION
By creating a new printing method in Helpers, formatting can be
obfuscated out of each class that requires printing a list of available
commands. The formatting should now be the same regardless of which
option list is being printed.