### PR TITLE
File Creation/Loading Now Respects Operating System

### DIFF
--- a/src/main/java/OS.java
+++ b/src/main/java/OS.java
@@ -82,8 +82,17 @@ public class OS {
      */
     private static UserConfig loadUserConfig() {
         UserConfig config = new UserConfig(Game.BN1);
+        String operatingSystem = Helpers.getOperatingSystem();
         String absolutePath = System.getProperty("user.dir");
-        String absoluteConfigPath = absolutePath + PathConstants.userConfigPath;
+        String absoluteConfigPath = "";
+        switch (operatingSystem) {
+            case "Linux" -> {
+                absoluteConfigPath = absolutePath + PathConstants.unixUserConfigPath;
+            }
+            case "Windows" -> {
+                absoluteConfigPath = absolutePath + PathConstants.userConfigPath;
+            }
+        }
         Path configPath = Paths.get(absoluteConfigPath);
         InputStream inputStream = null;
         try {
@@ -112,12 +121,16 @@ public class OS {
                 }
             } catch (SecurityException ex) {
                 errorPrint("Permission to write to path denied.");
+                errorPrint(ex.getMessage());
             } catch (FileAlreadyExistsException ex) {
                 errorPrint("An error occurred while creating the default config, one was already present?");
+                errorPrint(ex.getMessage());
             } catch (IOException ex) {
                 errorPrint("An issue occurred while setting up the user config.");
+                errorPrint(ex.getMessage());
             } catch (JsonIOException ex) {
                 errorPrint("An error occurred while creating the default JSON file.");
+                errorPrint(ex.getMessage());
             }
         }
         Reader reader = new InputStreamReader(inputStream);

--- a/src/main/java/constants/PathConstants.java
+++ b/src/main/java/constants/PathConstants.java
@@ -18,6 +18,7 @@ public class PathConstants {
     private static final String compressionCodeLibraryJson = "Compression Codes.json";
 
     public static final String userConfigPath = "\\config\\UserConfig.json";
+    public static final String unixUserConfigPath = "/config/UserConfig.json";
 
 
     //Battle Network 3 Constants

--- a/src/main/java/systems/utility/Helpers.java
+++ b/src/main/java/systems/utility/Helpers.java
@@ -27,6 +27,14 @@ public class Helpers {
     }
 
     /**
+     * Obtains the current operating system to determine file system semantics.
+     * @return a {@link String} representing the current operating system.
+     */
+    public static String getOperatingSystem() {
+        return System.getProperty("os.name");
+    }
+
+    /**
      * Constructs a list of selectable options.
      * <p>
      * For a list of three options, they are displayed as follows:


### PR DESCRIPTION
Previously, the config that the helper uses to determine username and
current game would only properly function when launched on a Windows
machine. Now, the operating system is dynamically determined and path
variables used reflect the determined system.